### PR TITLE
Hotfix for network restart handler

### DIFF
--- a/roles/base/handlers/main.yml
+++ b/roles/base/handlers/main.yml
@@ -1,5 +1,5 @@
 - name: networking
-  service: name=networking state=reloaded
+  shell: (ifdown --exclude=lo -a && ifup --exclude=lo -a)&
 - name: iptables
   command: /etc/network/if-up.d/iptables
 - name: ntp


### PR DESCRIPTION
Bug #1301015 reported by Simon Green on 2014-04-01 states that the
breakage of the classic /etc/init.d/networking restart is a new
"feature" and that it was never intended to work in the first
place.  Despite mountains of historical documentation as well as
the bug being filed as a build-breaker, the issue remains
unresolved.

This hotfix attempts to workaround the politics of the Canonical
developers by forcing all interfaces excluding lo0 into a down
state, followed by bringing all interfaces to the up state.

NOTE: This is not a long term fix, this is designed to prevent
the automated server provisioning system from failing by
forcing an interface reload.  This kludge is to be re-evaluated
upon switching to systemd to determine if it is still necessary.